### PR TITLE
OMIT - OLD Photos context

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,21 +1,59 @@
-import { StatusBar } from 'expo-status-bar';
-import React from 'react';
-import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { StatusBar } from "expo-status-bar";
+import React, { useState, useEffect } from "react";
+import { SafeAreaProvider } from "react-native-safe-area-context";
 
-import useCachedResources from './src/hooks/useCachedResources';
-import useColorScheme from './src/hooks/useColorScheme';
-import Navigation from './src/navigation';
+import useCachedResources from "./src/hooks/useCachedResources";
+import useColorScheme from "./src/hooks/useColorScheme";
+import Navigation from "./src/navigation";
+
+import { PhotosContext } from "./src/context";
+import useDataApi from "./src/hooks/useDataApi";
+import { ItemT } from "./src/components/Item";
 
 export default function App() {
   const isLoadingComplete = useCachedResources();
   const colorScheme = useColorScheme();
+
+  const [{ data, isLoading, isError }, doFetch] = useDataApi(
+    [],
+    "https://picsum.photos/v2/list?page=3&limit=100"
+  );
+  const [photos, setPhotos] = useState<Array<ItemT>>([]);
+
+  useEffect(() => {
+    setPhotos(data.map((photo) => ({ ...photo, isFavorite: false })));
+  }, [data]);
+
+  const photosContextValue = {
+    fetchedData: data,
+    isLoading: isLoading,
+    isError: isError,
+    fetchPhotos: doFetch,
+    photos: photos,
+    toggleFavorite: (id: string) => {
+      setPhotos((prevPhotos) => {
+        if (prevPhotos.length > 0) {
+          return prevPhotos.map((photo) =>
+            photo.id === id
+              ? { ...photo, isFavorite: !photo.isFavorite }
+              : photo
+          );
+        }
+        return [];
+      });
+    },
+  };
 
   if (!isLoadingComplete) {
     return null;
   } else {
     return (
       <SafeAreaProvider>
-        <Navigation colorScheme={colorScheme} />
+        <PhotosContext.Provider
+          value={photosContextValue}
+        >
+          <Navigation colorScheme={colorScheme} />
+        </PhotosContext.Provider>
         <StatusBar />
       </SafeAreaProvider>
     );

--- a/App.tsx
+++ b/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
 
   const [{ data, isLoading, isError }, doFetch] = useDataApi(
     [],
-    "https://picsum.photos/v2/list?page=3&limit=100"
+    "https://picsum.photos/v2/list?page=1&limit=100"
   );
   const [photos, setPhotos] = useState<Array<ItemT>>([]);
 

--- a/src/components/Item.tsx
+++ b/src/components/Item.tsx
@@ -1,35 +1,37 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Alert } from "react-native";
-import styled from 'styled-components/native';
+import styled from "styled-components/native";
 
 import Icon from "./Icon";
+
+import { PhotosContext } from "../context";
 
 export type ItemT = {
   id: string;
   author: string;
   download_url: string;
   isFavorite: boolean;
-}
+};
 
 /**
  * A single image
  */
 const Item = ({ id, author, download_url, isFavorite }: ItemT) => {
-  const toggleFavorite = (_id: string) => {};
+  const { toggleFavorite } = useContext(PhotosContext);
 
   return (
     <Wrapper
       onPress={() => {
-        Alert.alert("Photographer", author, [{ text: "OK" }], { cancelable: false });
+        Alert.alert("Photographer", author, [{ text: "OK" }], {
+          cancelable: false,
+        });
       }}
     >
       <Image
         style={{ width: 300, height: 300 }}
         source={{ uri: download_url }}
       />
-      <FavoriteButton
-        onPress={() => toggleFavorite(id)}
-      >
+      <FavoriteButton onPress={() => toggleFavorite(id)}>
         <Icon name={`md-star${isFavorite ? "" : "-outline"}`} />
       </FavoriteButton>
     </Wrapper>

--- a/src/components/PhotoList.tsx
+++ b/src/components/PhotoList.tsx
@@ -1,25 +1,20 @@
-import React, { useEffect, useState, FunctionComponent } from "react";
+import React, { FunctionComponent } from "react";
 import { ActivityIndicator, FlatList } from "react-native";
 
 import Item, { ItemT } from "./Item";
-import useDataApi from "../hooks/useDataApi";
 
-const PhotoList = () => {
-  const [{ data, isLoading, isError }, doFetch] = useDataApi(
-    [],
-    "https://picsum.photos/v2/list?page=1&limit=100"
-  );
+type PhotoListPropsT = {
+  isLoading: boolean;
+  photos: Array<ItemT>;
+}
 
-  useEffect(() => {
-    doFetch("https://picsum.photos/v2/list?page=3&limit=100");
-  }, []);
-
-  const renderItem: FunctionComponent<{ item: ItemT }> = ({ item }) => (
+const PhotoList: FunctionComponent<PhotoListPropsT> = ({ isLoading, photos }) => {
+  const renderItem = ({ item }: { item: ItemT }) => (
     <Item
       id={item.id}
       download_url={item.download_url}
       author={item.author}
-      isFavorite={false}
+      isFavorite={item.isFavorite}
     />
   );
 
@@ -27,7 +22,7 @@ const PhotoList = () => {
     <ActivityIndicator />
   ) : (
     <FlatList
-      data={data}
+      data={photos}
       renderItem={renderItem}
       keyExtractor={({ id }) => id}
     />

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { ItemT } from "./components/Item";
+
+type PhotosContextProps = {
+  fetchedData: ReadonlyArray<ItemT>;
+  isLoading: boolean;
+  isError: boolean;
+  fetchPhotos: (url: string) => void;
+  photos: Array<ItemT>;
+  toggleFavorite: (id: string) => void;
+};
+
+/**
+ * Context with default values
+ */
+export const PhotosContext = React.createContext<PhotosContextProps>({
+  fetchedData: [],
+  isLoading: false,
+  isError: false,
+  fetchPhotos: _url => {},
+  photos: [],
+  toggleFavorite: _id => {},
+});

--- a/src/hooks/useDataApi.ts
+++ b/src/hooks/useDataApi.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 
 import { ItemT } from "../components/Item";
 
@@ -12,6 +12,8 @@ const useDataApi = (initialData: ReadonlyArray<ItemT>, initialUrl: string) => {
   const [url, setUrl] = useState(initialUrl);
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
+
+  const isInitialMount = useRef(true);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -30,7 +32,12 @@ const useDataApi = (initialData: ReadonlyArray<ItemT>, initialUrl: string) => {
       setIsLoading(false);
     };
 
-    fetchData();
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+    } else {
+      // Is only run on update, not on initial mount
+      fetchData();
+    }
   }, [url]);
 
   return [{ data, isLoading, isError }, setUrl] as const;

--- a/src/screens/FavoritesScreen.tsx
+++ b/src/screens/FavoritesScreen.tsx
@@ -1,34 +1,37 @@
-import React, { FunctionComponent } from "react";
-import { StyleSheet, View, Text } from "react-native";
+import React, { FunctionComponent, useContext } from "react";
+import { View, Text } from "react-native";
+import styled from "styled-components/native";
 
 import PhotoList from "../components/PhotoList";
 import { ItemT } from "../components/Item";
 
+import { PhotosContext } from "../context";
+
 /**
- * Fetch and display random photos
+ * Display picked favorites
  */
 const FavoritesScreen: FunctionComponent<ItemT> = () => {
-  const favorites: ReadonlyArray<ItemT> = [];
+  const { photos, isLoading } = useContext(PhotosContext);
 
   return (
-    <View style={styles.container}>
-      {favorites.length > 0 ? (
-          <PhotoList />
+    <ListWrapper>
+      {photos.length > 0 ? (
+        <PhotoList
+          isLoading={isLoading}
+          photos={photos.filter((photo) => photo.isFavorite)}
+        />
       ) : (
         <View style={{ flex: 1, justifyContent: "center" }}>
           <Text>No favorites yet</Text>
         </View>
       )}
-    </View>
+    </ListWrapper>
   );
 };
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#fff",
-    alignItems: "center"
-  },
-});
+const ListWrapper = styled.View`
+  /* children */
+  align-items: center;
+`;
 
 export default FavoritesScreen;

--- a/src/screens/PhotosScreen.tsx
+++ b/src/screens/PhotosScreen.tsx
@@ -1,21 +1,26 @@
-import React from "react";
+import React, { useContext, useEffect } from "react";
 import styled from "styled-components/native";
 
 import PhotoList from "../components/PhotoList";
 
+import { PhotosContext } from "../context";
+
+/**
+ * Display all fetched photos
+ */
 const PhotosScreen = () => {
+  const { photos, isLoading } = useContext(PhotosContext);
+
   return (
     <>
       <ListWrapper>
-        <PhotoList />
+        <PhotoList isLoading={isLoading} photos={photos} />
       </ListWrapper>
     </>
   );
 };
 
 const ListWrapper = styled.View`
-  background-color: white;
-
   /* children */
   align-items: center;
 `;

--- a/src/screens/PhotosScreen.tsx
+++ b/src/screens/PhotosScreen.tsx
@@ -9,7 +9,11 @@ import { PhotosContext } from "../context";
  * Display all fetched photos
  */
 const PhotosScreen = () => {
-  const { photos, isLoading } = useContext(PhotosContext);
+  const { photos, fetchPhotos, isLoading } = useContext(PhotosContext);
+
+  useEffect(() => {
+    fetchPhotos("https://picsum.photos/v2/list?page=3&limit=100");
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
Add **react context** to share state in different screens. This is necessary for the Favorites to be shown in a separate tab.

Result:

<img width="584" alt="Screenshot 2020-08-27 at 09 59 10" src="https://user-images.githubusercontent.com/1945462/91413834-fa6f2280-e84b-11ea-9cd1-6307bbc80cd7.png">
