### PR TITLE
10 - Fix: PhotoScreen not updating after state change

### DIFF
--- a/src/store/reducer/photos.ts
+++ b/src/store/reducer/photos.ts
@@ -23,22 +23,32 @@ const photosReducer = (
   state = defaultState,
   action: PhotosActionT
 ) => {
+  // Shallow copy of current state to create a new reference to this slice of the state
+  const newState = {
+    ...state,
+  };
+
   switch (action.type) {
     case PHOTOS_FETCH_START:
-      state.isLoading = true;
+      newState.isLoading = true;
+      newState.error = undefined;
       break;
     case PHOTOS_FETCH_SUCCESS:
-      state.data = action.photos.map((photo) => ({
+      newState.data = action.photos.map((photo) => ({
         ...photo,
         isFavorite: false,
       }));
-      state.isLoading = false;
+      newState.error = undefined;
+      newState.isLoading = false;
       break;
     case PHOTOS_FETCH_ERROR:
-      state.error = action.error;
+      newState.error = action.error;
+      newState.isLoading = false;
+      newState.data = [];
+      break;
       break;
   }
-  return state;
+  return newState;
 };
 
 export default photosReducer;


### PR DESCRIPTION
Photos reducer now creates a new reference as returned slice of state.