### PR TITLE
17 - Move photos fetch code from screen into hook

### DIFF
--- a/src/hooks/redux/usePhotos.ts
+++ b/src/hooks/redux/usePhotos.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { Dispatch } from "@reduxjs/toolkit";
+
+import { RootStateT } from "../../store/slices/index";
+import {
+  photosSelector,
+  fetchPhotos,
+  PhotosDataT,
+  PhotosT,
+} from "../../store/slices/photos";
+
+const usePhotos = (): {
+  data: PhotosDataT;
+  isLoading: boolean;
+} => {
+  const dispatch = useDispatch<Dispatch<any>>();
+  const { data, isLoading } = useSelector<RootStateT, PhotosT>(photosSelector);
+
+  useEffect(() => {
+    dispatch(fetchPhotos());
+  }, []);
+
+  return { data, isLoading };
+};
+
+export default usePhotos;

--- a/src/screens/PhotosScreen.tsx
+++ b/src/screens/PhotosScreen.tsx
@@ -1,20 +1,11 @@
-import React, { useEffect, Dispatch } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import React from "react";
 import styled from "styled-components/native";
 
-import { fetchPhotos, photosSelector, PhotosT } from "../store/slices/photos";
-import { RootStateT } from "../store/slices";
-
+import usePhotos from '../hooks/redux/usePhotos';
 import PhotoList from "../components/PhotoList";
 
 const PhotosScreen = () => {
-  const dispatch = useDispatch<Dispatch<any>>();
-
-  useEffect(() => {
-    dispatch(fetchPhotos());
-  }, []);
-
-  const { data, isLoading } = useSelector<RootStateT, PhotosT>(photosSelector);
+  const { data, isLoading } = usePhotos();
 
   return (
     <>


### PR DESCRIPTION
We encapsulated the fetch code from the screen.
In this new hook `redux-toolkit` may be swapped with entirely different approaches to load data